### PR TITLE
Adding necessary reources file in /lib

### DIFF
--- a/lib/mail-x_smtpapi.rb
+++ b/lib/mail-x_smtpapi.rb
@@ -1,0 +1,4 @@
+require 'mail_x_smtpapi/version.rb'
+require 'mail_x_smtpapi/field.rb'
+require 'mail_x_smtpapi/accessors.rb'
+require 'mail/x_smtpapi.rb'


### PR DESCRIPTION
The mail-x_smtpapi.rb file is currently missing from the /lib directory, which results in a load error: 
"cannot load such file -- x-mail_smtpapi (LoadError)"
