### PR TITLE
upgrade to `mail` 2.8.1

### DIFF
--- a/lib/mail/x_smtpapi.rb
+++ b/lib/mail/x_smtpapi.rb
@@ -20,5 +20,4 @@ end
 MailXSMTPAPI::Field::FIELD_NAME.tap do |name|
   Mail::Field::FIELDS_MAP[name]     = MailXSMTPAPI::Field
   Mail::Field::FIELD_NAME_MAP[name] = MailXSMTPAPI::Field::CAPITALIZED_FIELD
-  Mail::Header::LIMITED_FIELDS      << name
 end

--- a/lib/mail_x_smtpapi/field.rb
+++ b/lib/mail_x_smtpapi/field.rb
@@ -7,6 +7,8 @@ module MailXSMTPAPI
     FIELD_NAME = 'x-smtpapi'
     CAPITALIZED_FIELD = 'X-SMTPAPI'
 
+    def self.singular? = true
+
     attr_reader :data
 
     # Accessors

--- a/lib/mail_x_smtpapi/version.rb
+++ b/lib/mail_x_smtpapi/version.rb
@@ -1,3 +1,3 @@
 module MailXSMTPAPI
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end

--- a/mail-x_smtpapi.gemspec
+++ b/mail-x_smtpapi.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.1"
   spec.add_development_dependency "minitest", "~> 5.21"
 
-  spec.add_dependency "mail", "~> 2.7.1"
+  spec.add_dependency "mail", "~> 2.8.1"
   spec.add_dependency "net-smtp"
 end


### PR DESCRIPTION
# What

Upgrades to `mail` `2.8.1`.

`singular?` is the new way to denote when a field should only have one value in `mail` 2.8.
`Mail::Header::LIMITED_FIELDS` has been removed.

fixes #7

# How

### `2.7.1` code:

1. `[]=` checks `limited_field?`:
https://github.com/mikel/mail/blob/7c43c84c16f017e0ff5e5c9962f6a1d842301ee3/lib/mail/header.rb#L162-L189
2. `limited_field?` checks `Mail::Header::LIMITED_FIELDS`:
https://github.com/mikel/mail/blob/7c43c84c16f017e0ff5e5c9962f6a1d842301ee3/lib/mail/header.rb#L266-L268

### `2.8.1` code:

1. `[]=` calls `add_field`:
https://github.com/mikel/mail/blob/b6b6cb737d47a85ddc720fda0e6b991e99224848/lib/mail/header.rb#L147-L167
2. `add_field` checks `#singular?`:
https://github.com/mikel/mail/blob/b6b6cb737d47a85ddc720fda0e6b991e99224848/lib/mail/field_list.rb#L22-L29
3. `#singular?` checks `.singular?`:
https://github.com/mikel/mail/blob/b6b6cb737d47a85ddc720fda0e6b991e99224848/lib/mail/fields/common_field.rb#L28-L30
4. `.singular?` defaults to `false`:
https://github.com/mikel/mail/blob/b6b6cb737d47a85ddc720fda0e6b991e99224848/lib/mail/fields/common_field.rb#L7-L9