### PR TITLE
[Fix #11] Fix Bundler autorequire paths for smtpapi extension

### DIFF
--- a/lib/mail-x_smtpapi-ksr.rb
+++ b/lib/mail-x_smtpapi-ksr.rb
@@ -1,0 +1,1 @@
+require_relative 'mail-x_smtpapi'

--- a/lib/mail/x_smtpapi/ksr.rb
+++ b/lib/mail/x_smtpapi/ksr.rb
@@ -1,0 +1,1 @@
+require_relative '../../mail-x_smtpapi'

--- a/lib/mail_x_smtpapi/version.rb
+++ b/lib/mail_x_smtpapi/version.rb
@@ -1,3 +1,3 @@
 module MailXSMTPAPI
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end

--- a/test/mail_autorequire_test.rb
+++ b/test/mail_autorequire_test.rb
@@ -5,24 +5,43 @@ class MailAutorequireTest < Minitest::Test
   PROJECT_ROOT = File.expand_path('..', __dir__)
 
   def test_bundler_default_require_loads_smtpapi_extension
-    out, err, status = run_bundle_ruby('require "bundler"; Bundler.require(:default); require "mail"; puts Mail.new.respond_to?(:smtpapi)')
+    script = <<~RUBY
+      require 'bundler'
+      Bundler.require(:default)
+      require 'mail'
+      puts Mail.new.respond_to?(:smtpapi)
+    RUBY
+
+    out, err, status = run_bundle_ruby(script)
 
     assert status.success?, "Expected script to succeed, got:\n#{err}"
-    assert_equal "true\n", out
+    assert_equal 'true', out.chomp
   end
 
   def test_hyphenated_gem_name_is_requireable
-    out, err, status = run_bundle_ruby('require "mail-x_smtpapi-ksr"; require "mail"; puts Mail.new.respond_to?(:smtpapi)')
+    script = <<~RUBY
+      require 'mail-x_smtpapi-ksr'
+      require 'mail'
+      puts Mail.new.respond_to?(:smtpapi)
+    RUBY
+
+    out, err, status = run_bundle_ruby(script)
 
     assert status.success?, "Expected script to succeed, got:\n#{err}"
-    assert_equal "true\n", out
+    assert_equal 'true', out.chomp
   end
 
   def test_slash_form_is_requireable
-    out, err, status = run_bundle_ruby('require "mail/x_smtpapi/ksr"; require "mail"; puts Mail.new.respond_to?(:smtpapi)')
+    script = <<~RUBY
+      require 'mail/x_smtpapi/ksr'
+      require 'mail'
+      puts Mail.new.respond_to?(:smtpapi)
+    RUBY
+
+    out, err, status = run_bundle_ruby(script)
 
     assert status.success?, "Expected script to succeed, got:\n#{err}"
-    assert_equal "true\n", out
+    assert_equal 'true', out.chomp
   end
 
   private

--- a/test/mail_autorequire_test.rb
+++ b/test/mail_autorequire_test.rb
@@ -1,0 +1,35 @@
+require_relative 'test_helper'
+require 'open3'
+
+class MailAutorequireTest < Minitest::Test
+  PROJECT_ROOT = File.expand_path('..', __dir__)
+
+  def test_bundler_default_require_loads_smtpapi_extension
+    out, err, status = run_bundle_ruby('require "bundler"; Bundler.require(:default); require "mail"; puts Mail.new.respond_to?(:smtpapi)')
+
+    assert status.success?, "Expected script to succeed, got:\n#{err}"
+    assert_equal "true\n", out
+  end
+
+  def test_hyphenated_gem_name_is_requireable
+    out, err, status = run_bundle_ruby('require "mail-x_smtpapi-ksr"; require "mail"; puts Mail.new.respond_to?(:smtpapi)')
+
+    assert status.success?, "Expected script to succeed, got:\n#{err}"
+    assert_equal "true\n", out
+  end
+
+  def test_slash_form_is_requireable
+    out, err, status = run_bundle_ruby('require "mail/x_smtpapi/ksr"; require "mail"; puts Mail.new.respond_to?(:smtpapi)')
+
+    assert status.success?, "Expected script to succeed, got:\n#{err}"
+    assert_equal "true\n", out
+  end
+
+  private
+
+  def run_bundle_ruby(script)
+    Bundler.with_unbundled_env do
+      Open3.capture3('bundle', 'exec', 'ruby', '-e', script, chdir: PROJECT_ROOT)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #11

This issue was caused by 46d41c260d633bed0fa9426672435b0bb4796659.
I changed the name of the gem, but neglected to update the module structure to match.  Bundler has a convention of requiring modules based on the gem's name.